### PR TITLE
Merge develop into main for v1.25.2

### DIFF
--- a/error/sys.go
+++ b/error/sys.go
@@ -1,0 +1,11 @@
+package error
+
+import "errors"
+
+var (
+	// ErrShutdownSignalsInitialized 表示底层信号订阅已初始化，不能再修改关闭信号。
+	ErrShutdownSignalsInitialized = errors.New("shutdown signals already initialized")
+
+	// ErrInvalidShutdownSignals 表示关闭信号为空或包含 nil。
+	ErrInvalidShutdownSignals = errors.New("shutdown signals cannot be empty or contain nil")
+)

--- a/sys/shutdown.go
+++ b/sys/shutdown.go
@@ -7,10 +7,19 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	toolkitError "github.com/acexy/golang-toolkit/error"
 )
 
-var defaultShutdownSig = []os.Signal{syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGHUP, syscall.SIGALRM}
+var defaultShutdownSig = []os.Signal{
+	syscall.SIGINT,
+	syscall.SIGTERM,
+	syscall.SIGQUIT,
+}
 
+var shutdownSignalMu sync.Mutex
+var shutdownSignals = defaultShutdownSig
+var shutdownSignalsInitialized bool
 var exitSignChan = make(chan struct{})
 var exitOnce sync.Once
 
@@ -25,25 +34,49 @@ func holding(sig ...os.Signal) os.Signal {
 	return <-ch // 返回捕获的信号
 }
 
-// ShutdownHolding 监听指定的信号，若不传递则使用默认信号
-// 方法会一直阻塞直到触发所监听的信号为止
-func ShutdownHolding(sig ...os.Signal) {
-	holding(sig...)
+// SetShutdownSignals 设置进程级关闭信号。
+// 该方法必须在首次初始化底层信号订阅前调用，且信号不能为空或包含 nil。
+func SetShutdownSignals(sig ...os.Signal) error {
+	if len(sig) == 0 {
+		return toolkitError.ErrInvalidShutdownSignals
+	}
+	for _, item := range sig {
+		if item == nil {
+			return toolkitError.ErrInvalidShutdownSignals
+		}
+	}
+
+	shutdownSignalMu.Lock()
+	defer shutdownSignalMu.Unlock()
+	if shutdownSignalsInitialized {
+		return toolkitError.ErrShutdownSignalsInitialized
+	}
+	shutdownSignals = append([]os.Signal(nil), sig...)
+	return nil
 }
 
-// ShutdownCallback 监听指定的信号，若不传递则使用默认信号
-// 方法会一直阻塞直到触发所监听的信号为止，并执行回调
-func ShutdownCallback(f func(), sig ...os.Signal) {
-	holding(sig...)
+// ShutdownHolding 阻塞等待进程级共享的关闭信号。
+func ShutdownHolding() {
+	<-ShutdownSignal()
+}
+
+// ShutdownCallback 阻塞等待进程级共享的关闭信号，收到信号后同步执行回调。
+func ShutdownCallback(f func()) {
+	<-ShutdownSignal()
 	if f != nil {
 		f()
 	}
 }
 
-// ShutdownSignal 监听指定的信号，若不传递则使用默认信号
-// 方法返回一个信道，该信道会在所监听的信号被触发时关闭
-func ShutdownSignal(sig ...os.Signal) <-chan struct{} {
+// ShutdownSignal 返回进程级共享的关闭信道。
+// 底层仅订阅一次系统信号；未调用 SetShutdownSignals 时使用默认关闭信号。
+// 收到任一监听信号后，共享信道会被关闭并通知所有监听者。
+func ShutdownSignal() <-chan struct{} {
 	exitOnce.Do(func() {
+		shutdownSignalMu.Lock()
+		shutdownSignalsInitialized = true
+		sig := append([]os.Signal(nil), shutdownSignals...)
+		shutdownSignalMu.Unlock()
 		go func() {
 			holding(sig...)
 			close(exitSignChan)
@@ -52,18 +85,36 @@ func ShutdownSignal(sig ...os.Signal) <-chan struct{} {
 	return exitSignChan
 }
 
-// ShutdownCallbackDeadline 监听指定的信号，若不传递则使用默认信号
-// 方法会一直阻塞直到触发所监听的信号为止 并执行回调 若在指定时间未完成回调执行，则放弃等待
-func ShutdownCallbackDeadline(f func(), deadline time.Duration, sig ...os.Signal) {
-	holding(sig...)
+// ShutdownContext 返回一个可取消的 context。
+// 父 context、调用方主动取消或进程收到关闭信号时，返回的 context 会被取消。
+// 该方法复用进程级共享的信号订阅。
+func ShutdownContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctxNew, cancel := context.WithCancel(ctx)
+	go func() {
+		select {
+		case <-ShutdownSignal():
+			cancel()
+		case <-ctxNew.Done():
+		}
+	}()
+	return ctxNew, cancel
+}
+
+// ShutdownCallbackDeadline 阻塞等待进程级共享的关闭信号，收到信号后执行回调。
+// 超过指定等待时间后方法返回，但不会强制终止仍在执行的回调。
+func ShutdownCallbackDeadline(f func(), deadline time.Duration) {
+	<-ShutdownSignal()
 	ctx, cancel := context.WithTimeout(context.Background(), deadline)
 	defer cancel()
 	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		if f != nil {
 			f()
 		}
-		done <- struct{}{}
 	}()
 	select {
 	case <-ctx.Done():


### PR DESCRIPTION
## Summary

- Unify shutdown signal handling in the `sys` package.
- Add reusable sentinel errors for shutdown signal validation.

## Changes

- Add `error/sys.go`.
- Update `sys/shutdown.go`.

## Validation

- Tests and builds were not run as required by the release workflow.